### PR TITLE
Flatten arrays returned by `getFieldData`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const BaseController = require('hof-controllers').base;
 
 module.exports = class ConfirmController extends BaseController {
@@ -15,7 +16,7 @@ module.exports = class ConfirmController extends BaseController {
             `pages.confirm.sections.${section}.header`,
             `pages.${section}.header`
           ]),
-          fields: fields.map(field => this.getFieldData(field, req)).filter(f => f.value)
+          fields: _.flatten(fields.map(field => this.getFieldData(field, req))).filter(f => f.value)
         };
       })
       .filter(section => section.fields.length);

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "homepage": "https://github.com/UKHomeOfficeForms/hof-confirm-controller#readme",
   "dependencies": {
-    "hof-controllers": "^6.0.2"
+    "hof-controllers": "^6.0.2",
+    "lodash": "^4.17.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -204,6 +204,31 @@ describe('Confirm Controller', () => {
       expect(req.translate).to.have.been.calledWithExactly(['pages.confirm.sections.two.header', 'pages.two.header']);
     });
 
+    it('flattens fields if a custom implementation of `getFieldData` returns array for a field', () => {
+      req.sessionModel.set({
+        'field-one': 1
+      });
+      req.form.options.sections = {
+        'section-one': ['field-one']
+      };
+      controller.getFieldData = () => {
+        return [
+          {
+            label: 'one',
+            value: 1
+          },
+          {
+            label: 'two',
+            value: 2
+          }
+        ];
+      };
+      const result = controller.locals(req, res);
+      expect(result.rows[0].fields.length).to.equal(2);
+      expect(result.rows[0].fields[0].label).to.equal('one');
+      expect(result.rows[0].fields[1].label).to.equal('two');
+    });
+
   });
 
 });


### PR DESCRIPTION
This allows extensions of the `getFieldData` method to return an array if a single field should be represented by more than one row.

It's not used directly in this project, but makes extension and customisation much easier.