### PR TITLE
Bugfix - don't show empty fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,21 @@
 
 const _ = require('lodash');
 
+const isTruthy = (model, field) => {
+  field = typeof field === 'object' ? field.field : field;
+  const value = model.get(field);
+  return value !== '' && value !== null && value !== undefined;
+};
+
+const getValue = (value, field, translate) => {
+  const key = `fields.${field}.options.${value}.label`;
+  let result = translate(key);
+  if (result === key) {
+    result = value;
+  }
+  return result;
+};
+
 module.exports = SuperClass => class extends SuperClass {
 
   parseSections(req) {
@@ -15,7 +30,9 @@ module.exports = SuperClass => class extends SuperClass {
             `pages.confirm.sections.${section}.header`,
             `pages.${section}.header`
           ]),
-          fields: _.flatten(fields.map(field => this.getFieldData(field, req))).filter(f => f.value)
+          fields: _.flatten(fields.filter(field => isTruthy(req.sessionModel, field))
+            .map(field => this.getFieldData(field, req)))
+            .filter(f => f.value)
         };
       })
       .filter(section => section.fields.length);
@@ -46,10 +63,11 @@ module.exports = SuperClass => class extends SuperClass {
       return {
         label: req.translate([
           `pages.confirm.fields.${key}.label`,
+          `fields.${key}.summary`,
           `fields.${key}.label`,
           `fields.${key}.legend`
         ]),
-        value: req.sessionModel.get(key) || settings.nullValue,
+        value: getValue(req.sessionModel.get(key), key, req.translate) || settings.nullValue,
         step: this.getStepForField(key, settings.steps),
         field: key
       };

--- a/test/index.js
+++ b/test/index.js
@@ -87,7 +87,7 @@ describe('Summary Page Behaviour', () => {
         'field-two': 2
       });
       req.form.options.sections = {
-        'section-one': ['field-one', 'field-two']
+        'section-one': ['field-one', 'field-two', 'field-three']
       };
       const result = controller.locals(req, res);
       expect(result.rows[0]).to.have.a.property('fields');
@@ -95,6 +95,7 @@ describe('Summary Page Behaviour', () => {
       expect(result.rows[0].fields.length).to.equal(2);
       expect(result.rows[0].fields[0].field).to.equal('field-one');
       expect(result.rows[0].fields[1].field).to.equal('field-two');
+      expect(result.rows[0].fields).not.to.include('field-three');
     });
 
     it('ignores fields with no value set', () => {
@@ -108,20 +109,6 @@ describe('Summary Page Behaviour', () => {
       expect(result.rows[0].fields.length).to.equal(1);
       expect(result.rows[0].fields[0].field).to.equal('field-one');
       expect(result.rows[0].fields[0].value).to.equal(1);
-    });
-
-    it('uses a nullValue for empty fields if defined', () => {
-      req.sessionModel.set({
-        'field-one': 1
-      });
-      req.form.options.nullValue = '-';
-      req.form.options.sections = {
-        'section-one': ['field-one', 'field-two']
-      };
-      const result = controller.locals(req, res);
-      expect(result.rows[0].fields.length).to.equal(2);
-      expect(result.rows[0].fields[0].value).to.equal(1);
-      expect(result.rows[0].fields[1].value).to.equal('-');
     });
 
     it('calculates the step for each field based on steps config', () => {


### PR DESCRIPTION
* If a user forks and skips certain fields, they are currently still shown in the summary table. These fields are often irrelevant. Added a filter to check if field value is null, undefined, or ''.
* Added fields.{fieldName}.summary key back as breaks previous implementations
* Display label from translation if present (radio)