### PR TITLE
Fix field filtering and default values

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -2,12 +2,6 @@
 
 const _ = require('lodash');
 
-const isTruthy = (model, field) => {
-  field = typeof field === 'object' ? field.field : field;
-  const value = model.get(field);
-  return value !== '' && value !== null && value !== undefined;
-};
-
 const getValue = (value, field, translate) => {
   const key = `fields.${field}.options.${value}.label`;
   let result = translate(key);
@@ -30,9 +24,14 @@ module.exports = SuperClass => class extends SuperClass {
             `pages.confirm.sections.${section}.header`,
             `pages.${section}.header`
           ]),
-          fields: _.flatten(fields.filter(field => isTruthy(req.sessionModel, field))
-            .map(field => this.getFieldData(field, req)))
-            .filter(f => f.value)
+          fields: _.flatten(fields.map(field => this.getFieldData(field, req)))
+            .map(f => {
+              if (!f.value && f.value !== 0 && settings.nullValue) {
+                f.value = settings.nullValue;
+              }
+              return f;
+            })
+            .filter(f => (f.value || f.value === 0))
         };
       })
       .filter(section => section.fields.length);
@@ -67,7 +66,7 @@ module.exports = SuperClass => class extends SuperClass {
           `fields.${key}.label`,
           `fields.${key}.legend`
         ]),
-        value: getValue(req.sessionModel.get(key), key, req.translate) || settings.nullValue,
+        value: getValue(req.sessionModel.get(key), key, req.translate),
         step: this.getStepForField(key, settings.steps),
         field: key
       };

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ module.exports = SuperClass => class extends SuperClass {
           fields: _.flatten(fields.map(field => this.getFieldData(field, req)))
             .map(f => {
               if (!f.value && f.value !== 0 && settings.nullValue) {
-                f.value = settings.nullValue;
+                f.value = req.translate(settings.nullValue);
               }
               return f;
             })

--- a/test/index.js
+++ b/test/index.js
@@ -111,6 +111,48 @@ describe('Summary Page Behaviour', () => {
       expect(result.rows[0].fields[0].value).to.equal(1);
     });
 
+    it('includes zero valued fields', () => {
+      req.sessionModel.set({
+        'field-one': 0
+      });
+      req.form.options.sections = {
+        'section-one': ['field-one', 'field-two']
+      };
+      const result = controller.locals(req, res);
+      expect(result.rows[0].fields.length).to.equal(1);
+      expect(result.rows[0].fields[0].field).to.equal('field-one');
+      expect(result.rows[0].fields[0].value).to.equal(0);
+    });
+
+    it('uses a nullValue for empty fields if defined', () => {
+      req.sessionModel.set({
+        'field-one': 1
+      });
+      req.form.options.nullValue = '-';
+      req.form.options.sections = {
+        'section-one': ['field-one', 'field-two']
+      };
+      const result = controller.locals(req, res);
+      expect(result.rows[0].fields.length).to.equal(2);
+      expect(result.rows[0].fields[0].value).to.equal(1);
+      expect(result.rows[0].fields[1].value).to.equal('-');
+    });
+
+    it('does not apply `nullValue` option to zero valued fields', () => {
+      req.sessionModel.set({
+        'field-one': 1,
+        'field-two': 0
+      });
+      req.form.options.nullValue = '-';
+      req.form.options.sections = {
+        'section-one': ['field-one', 'field-two']
+      };
+      const result = controller.locals(req, res);
+      expect(result.rows[0].fields.length).to.equal(2);
+      expect(result.rows[0].fields[0].value).to.equal(1);
+      expect(result.rows[0].fields[1].value).to.equal(0);
+    });
+
     it('calculates the step for each field based on steps config', () => {
       req.sessionModel.set({
         'field-one': 1,


### PR DESCRIPTION
Restores capability removed in https://github.com/UKHomeOfficeForms/hof-behaviour-summary-page/pull/4 for a default value to be used in place of undefined or empty values.

Also fixes functionality claimed to be added by that PR of not filtering zero-valued fields, which was broken due to the secondary pure-Boolean filter that was applied after the initial filter.

Now fields are only removed if they have a falsy, non-zero value *and* no default value is supplied.